### PR TITLE
Add PEP 604 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ py-sast:
 	$(PYTHON) -m pyflakes load_environ_typed test.py
 
 py-lint:
-	$(PYTHON) -m pycodestyle --ignore=E721 load_environ_typed test.py
+	$(PYTHON) -m pycodestyle --ignore=E721,W503 load_environ_typed test.py
 
 README.html: README.md
 	pandoc -f markdown -s --highlight-style pygments --metadata title="load-environ-typed README" $^ -o $@

--- a/load_environ_typed/__init__.py
+++ b/load_environ_typed/__init__.py
@@ -164,7 +164,8 @@ def check_optional(type_: Type[Any]) -> Tuple[Type[Any], bool]:
     if getattr(type_, '__origin__', None) is Optional:
         raise NotImplementedError('TODO')
 
-    if getattr(type_, '__origin__', None) is Union:
+    if ((getattr(type_, '__origin__', None) is Union)
+            or 'types.UnionType' in str(type(type_))):
         args = tuple(
             x
             for x in type_.__args__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "You define a class, we load it up from environment in a type safe way"
 readme = "README.md"
 license = {file = "LICENSE.txt" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This commit add PEP 604 support. The actual check is a bit finicky as I did not want to break the compatibility with Python 3.8 and 3.9. UnionType is available from 3.10 and up.

Also add `W503` to the ignore list and you have to choose `W503` or `W504` to keep pylint happy.