### PR TITLE
Add support for PEP 604 and forward reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ py-sast:
 	$(PYTHON) -m pyflakes load_environ_typed test.py
 
 py-lint:
-	$(PYTHON) -m pycodestyle --ignore=E721 load_environ_typed test.py
+	$(PYTHON) -m pycodestyle --ignore=E721,W503 load_environ_typed test.py
 
 README.html: README.md
 	pandoc -f markdown -s --highlight-style pygments --metadata title="load-environ-typed README" $^ -o $@

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "You define a class, we load it up from environment in a type safe way"
 readme = "README.md"
 license = {file = "LICENSE.txt" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/test.py
+++ b/test.py
@@ -366,6 +366,25 @@ class TestLoad(unittest.TestCase):
             # So we have to ignore it since we want to make sure it works
             environ.DB_NAME = 'tpk'  # type: ignore
 
+    def test_forward_reference_annotation(self) -> None:
+        @dataclass
+        class FrozenEnviron:
+            DB_NAME: 'str'
+
+        environ = sut.load(FrozenEnviron, environ={'DB_NAME': 'database'})
+
+        self.assertEqual(environ.DB_NAME, 'database')
+
+    @unittest.skipIf(sys.version_info < (3, 10), 'Python 3.10+ only')
+    def test_pep_604(self) -> None:
+        @dataclass
+        class FrozenEnviron:
+            DB_NAME: 'str | None'
+
+        environ = sut.load(FrozenEnviron, environ={'DB_NAME': 'database'})
+
+        self.assertEqual(environ.DB_NAME, 'database')
+
     @unittest.skipIf(sys.version_info < (3, 10), 'Python 3.10+ only')
     def test_kw_only(self) -> None:
         @dataclass(kw_only=True)  # type: ignore [call-overload,unused-ignore]


### PR DESCRIPTION
Prior to this commit, using a forward reference type annotation (i.e., a string) would fail to be detected properly. Similarly, a PEP 604 annotation using the pipe operator would fail.

This commit adds support and tests for both.
